### PR TITLE
Set renovate automerge setting to minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>hmcts/.github:renovate-config",
-    "local>hmcts/.github//renovate/automerge-all"
+    "local>hmcts/.github//renovate/automerge-minor"
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
CRF-1 (https://tools.hmcts.net/jira/browse/CRF-1)


### Change description ###
Changed renovate automerge setting to minor.  This is to guard against major changes being automatically merged when supporting changes aren't in place (e.g. DependencyCheck v9) or being implemented piecemeal (e.g. updating Docker Java version without updating build.gradle as well).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
