### PR TITLE
CRF-11: Remove logback.version property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,6 @@ ext {
   log4JVersion = "2.22.0"
 }
 
-ext['logback.version'] = '1.4.12'
 ext['snakeyaml.version'] = '2.0'
 
 dependencies {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CRF-11 (https://tools.hmcts.net/jira/browse/CRF-11)


### Change description ###
Removed logback.version property from build.gradle.  This is no longer needed following update to Spring Boot 3.2.1 which uses a version of logback that isn't affected by CVE-2023-6378.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
