### PR TITLE
Resolving alert logs quota exceeded error

### DIFF
--- a/infrastructure/app-insights.tf
+++ b/infrastructure/app-insights.tf
@@ -6,6 +6,7 @@ module "application_insights" {
   name                = "${var.product}-${var.component}-appinsights"
   location            = var.location
   resource_group_name = azurerm_resource_group.civil_rtl_export_rg.name
+  alert_limit_reached = true
 
   common_tags = var.common_tags
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Fixing issue regarding "current quota of 100 active activity log alert rules for subscription **** has been reached" error in the civil-rtl-export main pipeline

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
