### PR TITLE
CRF-12: Update database constraint

### DIFF
--- a/src/main/resources/db/migration/V0001__init.sql
+++ b/src/main/resources/db/migration/V0001__init.sql
@@ -60,7 +60,7 @@ ALTER TABLE judgments ADD CONSTRAINT j_def_add_pos_nn CHECK (defendant_address_p
 ------------------------------------------------
 -- Create Unique constraints for PUBLIC
 ------------------------------------------------
-ALTER TABLE judgments ADD CONSTRAINT j_ser_id_jud_id_uni UNIQUE (service_id, judgment_id);
+ALTER TABLE judgments ADD CONSTRAINT j_jud_eve_uni UNIQUE (service_id, judgment_id, judgment_event_timestamp, case_number);
 
 
 ------------------------------------------------


### PR DESCRIPTION
### JIRA link (if applicable) ###
CRF-12 (https://tools.hmcts.net/jira/browse/CRF-12)


### Change description ###
Replaced j_ser_id_jud_id_uni constraint with j_jud_eve_uni.  Original was too restrictive in that it would prevent other events in the lifecycle of a judgment from being stored once the first had been stored.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
