### PR TITLE
Set TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX env variable

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,4 +6,7 @@ def type = "java"
 def product = "civil"
 def component = "rtl-export"
 
+// Prevent Docker hub rate limit errors by ensuring that testcontainers uses images from hmctspublic ACR
+env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctspublic.azurecr.io/imported/"
+
 withPipeline(type, product, component) {}

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,4 +11,7 @@ def type = "java"
 def product = "civil"
 def component = "rtl-export"
 
+// Prevent Docker hub rate limit errors by ensuring that testcontainers uses images from hmctspublic ACR
+env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctspublic.azurecr.io/imported/"
+
 withNightlyPipeline(type, product, component) {}


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Set the TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX environment variable in Jenkinsfile_CNP and Jenkinsfile_nightly.  This prevents Docker hub rate limit errors by configuring testscontainers to use images from the HMCTS public ACR.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
