### PR TITLE
Create s2s service secret in key vault

### DIFF
--- a/infrastructure/key-vault.tf
+++ b/infrastructure/key-vault.tf
@@ -15,7 +15,6 @@ module "civil_rtl_export_key_vault" {
   common_tags                 = local.tags
   managed_identity_object_ids = [data.azurerm_user_assigned_identity.civil-mi.principal_id]
 }
-/* These key vault secrets will be re-instated once the service has been set up in IDAM
 
 data "azurerm_key_vault" "s2s_vault" {
   name                = "s2s-${var.env}"
@@ -32,4 +31,3 @@ resource "azurerm_key_vault_secret" "s2s" {
   value        = data.azurerm_key_vault_secret.key_from_vault.value
   key_vault_id = module.civil_rtl_export_key_vault.key_vault_id
 }
-*/


### PR DESCRIPTION
### JIRA link (if applicable) ###
CRF-12 (https://tools.hmcts.net/jira/browse/CRF-12)


### Change description ###
Uncommented code in key-vault.tf that sets up s2s service secret in civil-rtl-export key vaults.  This can be done as the corresponding microservicekey secret has now been set up in the s2s-aat key vault.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
