### PR TITLE
Set demo DB backup retention period

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,0 +1,1 @@
+database_backup_retention_days = 7


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated demo.tfvars to set database backup retention period to 7 days.  This overrides default of 35 days which is only intended for production.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
