### PR TITLE
CRF-22: Remove suppression of CVE-2025-48989

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,10 +15,8 @@
   <suppress>
     <notes>Temporary Suppressions
       CVE-2025-48976
-      CVE-2025-48989
     </notes>
     <cve>CVE-2025-48976</cve>
-    <cve>CVE-2025-48989</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CFR-22 (https://tools.hmcts.net/jira/browse/CRF-22)


### Change description ###
Suppression of CVE-2025-48989 should no longer be required as version of tomcat has been updated to a later version in Spring boot release 3.5.5 (see #332).



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
