### PR TITLE
CRF-24: Explicitly include flyway-core dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,7 @@ dependencies {
 
   implementation group: 'io.rest-assured', name: 'rest-assured'
 
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '11.12.0'
   implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '11.12.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.8'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.19.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###
CRF-24 (https://tools.hmcts.net/jira/browse/CRF-24)


### Change description ###
Added flyway-core dependency to build.gradle.  This ensures that the version of flyway-core matches that of the other flyway dependencies (and overrides Spring Boot default version).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
