### PR TITLE
CRF-28 and CRF-20: Remove CVE suppressions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,36 +17,10 @@
       CVE-2025-7962 - May be a false positive as angus_mail does not appear in dependency list
       CVE-2025-15104 - May be a false positive as Nu HTML checker does not appear in dependency list
       CVE-2025-48976 - See CRF-21
-      CVE-2026-41284 - See CRF-28
-      CVE-2026-41293 - See CRF-28
-      CVE-2026-41840 - See CRF-29
-      CVE-2026-41841 - See CRF-29
-      CVE-2026-41842 - See CRF-29
-      CVE-2026-41843 - See CRF-29
-      CVE-2026-41850 - See CRF-29
-      CVE-2026-41851 - See CRF-29
-      CVE-2026-42498 - See CRF-28
-      CVE-2026-43512 - See CRF-28
-      CVE-2026-43513 - See CRF-28
-      CVE-2026-43514 - See CRF-28
-      CVE-2026-43515 - See CRF-28
     </notes>
     <cve>CVE-2025-7962</cve>
     <cve>CVE-2025-15104</cve>
     <cve>CVE-2025-48976</cve>
-    <cve>CVE-2026-41284</cve>
-    <cve>CVE-2026-41293</cve>
-    <cve>CVE-2026-41840</cve>
-    <cve>CVE-2026-41841</cve>
-    <cve>CVE-2026-41842</cve>
-    <cve>CVE-2026-41843</cve>
-    <cve>CVE-2026-41850</cve>
-    <cve>CVE-2026-41851</cve>
-    <cve>CVE-2026-42498</cve>
-    <cve>CVE-2026-43512</cve>
-    <cve>CVE-2026-43513</cve>
-    <cve>CVE-2026-43514</cve>
-    <cve>CVE-2026-43515</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CRF-28](https://tools.hmcts.net/jira/browse/CRF-28) and [CRF-29](https://tools.hmcts.net/jira/browse/CRF-29)


### Change description ###
Removed suppression of Tomcat and Spring framework CVEs from suppressions.xml.  These CVEs have been addressed in release 3.5.15 of Spring Boot.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
